### PR TITLE
fix(handler): log transport error throwable at WARN

### DIFF
--- a/src/main/java/com/variocube/vcmp/VcmpHandler.java
+++ b/src/main/java/com/variocube/vcmp/VcmpHandler.java
@@ -109,8 +109,10 @@ public final class VcmpHandler implements WebSocketHandler {
 
     @Override
     public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
-        log.error("Transport error in session {}: {}", session.getId(), exception.getMessage());
-        log.debug("Full exception", exception);
+        // Transport errors are typically benign client disconnects (closed tab, dropped wifi,
+        // proxy timeout). Log at WARN with the throwable so the cause is visible when it
+        // matters, without paging on what is usually a normal lifecycle event.
+        log.warn("Transport error in session {}", session.getId(), exception);
         if (session.isOpen()) {
             session.close();
         }


### PR DESCRIPTION
## Summary

`VcmpHandler.handleTransportError` logged at ERROR with only `throwable.getMessage()` — which is frequently `null` — and put the actual stack at DEBUG. Result in production logs (see variocube/safecube#917):

```
ERROR [io-5000-exec-15] com.variocube.vcmp.VcmpHandler : Transport error in session 7683a5be-…: null
```

Unactionable as logged: no throwable class, no stack, no cause.

In practice transport errors here are dominated by benign client lifecycle events (browser tab closed, dropped wifi, intermediate proxy timeout). Treating each one as ERROR pages on what is mostly normal — and the missing throwable hides the rare genuine fault when it does happen.

This change:
- Downgrades the log to WARN.
- Passes the `Throwable` as the last SLF4J arg so its class, message and full stack land at the same level as the message — no more `: null`.
- Drops the separate DEBUG `log.debug("Full exception", exception)` line, which is now redundant.

Downstream impact: callers paying attention to ERROR-level entries from this class no longer fire on routine disconnects; if they want to keep alerting on transport-level failures they can filter at WARN.

## Test plan
- [ ] CI green.
- [ ] In a downstream consumer, induce a client disconnect (close browser, kill tunnel) and verify the log line now includes the throwable class and stack at WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)