### PR TITLE
fix(callback): ack VcmpCallback.all immediately when given no callbacks

### DIFF
--- a/src/main/java/com/variocube/vcmp/VcmpCallback.java
+++ b/src/main/java/com/variocube/vcmp/VcmpCallback.java
@@ -266,6 +266,12 @@ public class VcmpCallback<T> {
     public static <T> VcmpCallback<Collection<T>> all(Collection<VcmpCallback<T>> callbacks) {
         val combined = new VcmpCallback<Collection<T>>();
         val results = new ArrayList<T>();
+        // With no callbacks there is nothing to wait for, so ack immediately with an empty result.
+        // Otherwise the combined callback would remain PENDING forever (no per-callback ack ever fires).
+        if (callbacks.isEmpty()) {
+            combined.notifyAck(results);
+            return combined;
+        }
         for (val callback : callbacks) {
             callback.onAck(result -> {
                 results.add(result);

--- a/src/test/java/com/variocube/vcmp/VcmpCallbackTest.java
+++ b/src/test/java/com/variocube/vcmp/VcmpCallbackTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.*;
 
 class VcmpCallbackTest {
@@ -92,6 +93,12 @@ class VcmpCallbackTest {
     void canAllImmediateAck() {
         val results = VcmpCallback.all(VcmpCallback.completed(), VcmpCallback.completed()).await();
         assertThat(results).containsExactly(null, null);
+    }
+
+    @Test
+    void canAllEmptyAcksImmediately() {
+        val results = VcmpCallback.<Void>all(emptyList()).await();
+        assertThat(results).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Problem

`VcmpCallback.all(...)` only fires its terminal ACK once every per-callback ACK has arrived:

```java
callback.onAck(result -> {
    results.add(result);
    if (results.size() == callbacks.size()) {
        combined.notifyAck(results);
    }
});
```

When the collection is **empty**, the loop body never runs, so `notifyAck` is never called and the combined callback stays `PENDING` forever. Anyone awaiting it gets a 20s `REQUEST_TIMEOUT` instead of an immediate empty success.

This bites every fan-out `send(DeviceType, …)` that targets a device type with **no connected driver** — e.g. configuring a barcode reader, taking a kiosk screenshot, or ringing a doorbell while that device is offline. The caller perceives a timeout/failure rather than "nothing to do".

## Fix

Short-circuit the empty case: ack immediately with an empty result.

## Testing

- New `canAllEmptyAcksImmediately` asserts `all(emptyList())` resolves to an empty collection without blocking.
- Existing `VcmpCallbackTest` suite green.

## Context

Discovered while reviewing variocube/controller#126 (barcode-reader config pass-through), where the "configure while reader is offline" path is an explicitly supported scenario (config is persisted and re-sent on reconnect). Once this is released, controller can drop the local workaround and rely on the fan-out acking immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)