### PR TITLE
Fix MAX_SESSION_IDLE_TIMEOUT typo (60_1000 → 60_000)

### DIFF
--- a/src/main/java/com/variocube/vcmp/client/VcmpConnectionManager.java
+++ b/src/main/java/com/variocube/vcmp/client/VcmpConnectionManager.java
@@ -80,7 +80,7 @@ public class VcmpConnectionManager implements Closeable {
     /**
      * The maximum session idle timeout in milliseconds.
      */
-    private static final long MAX_SESSION_IDLE_TIMEOUT = 60_1000; // 60 seconds
+    private static final long MAX_SESSION_IDLE_TIMEOUT = 60_000; // 60 seconds
 
     private static final Random RANDOM = new Random();
 


### PR DESCRIPTION
Fixes #16

`MAX_SESSION_IDLE_TIMEOUT` was `60_1000` (601,000 ms ≈ 10 minutes), but the inline comment and intent indicate 60 seconds. Corrected to `60_000` (60,000 ms = 60 seconds).

Additional notes:
- One-line constant correction made via the GitHub web editor; I did not build or run the test suite locally. Correctness follows directly from the existing inline comment ("60 seconds") and the issue description. Happy to adjust if maintainers prefer a different value.
- Minor side effect worth flagging: idle sessions will now expire at the intended 60s instead of ~10 minutes, so this slightly tightens session-timeout behavior.

## Coder
- [ ] I paid attention to the warnings and errors the IDE gave me and I have fixed them where appropriate
- [ ] I wrote unit/integration tests where applicable
- [ ] I tested that the issue is resolved
- [ ] I tested that no regressions were introduced (other features still work)
- [ ] I tested edge cases
- [ ] I tested error cases and errors are handled correctly
- [ ] The build and tests have succeeded
- [x] There are no conflicts with the main / master branch
- [x] The changes have implications for IT security