### PR TITLE
fix(client): guard isRunning/webSocketSession with lifecycleMonitor

### DIFF
--- a/src/main/java/com/variocube/vcmp/client/VcmpConnectionManager.java
+++ b/src/main/java/com/variocube/vcmp/client/VcmpConnectionManager.java
@@ -153,26 +153,36 @@ public class VcmpConnectionManager implements Closeable {
     }
 
     private void scheduleReconnect(boolean afterDisconnect) {
-        webSocketSession = null;
-        if (this.isRunning) {
-            val baseDelay = afterDisconnect ? disconnectTimeout : Duration.ZERO;
-            val randomDelay = Duration.ofMillis(RANDOM.nextLong(reconnectTimeoutMin.toMillis(), reconnectTimeoutMax.toMillis() + 1));
-            val reconnectTimeoutMs = baseDelay.plus(randomDelay).toMillis();
-            log.info("Scheduling reconnect in {} ms", reconnectTimeoutMs);
-            try {
-                Executor.getExecutor().schedule(this::openSession, reconnectTimeoutMs, TimeUnit.MILLISECONDS);
-            }
-            catch (Exception e) {
-                log.error("Could not schedule reconnect", e);
+        // isRunning and webSocketSession are guarded by lifecycleMonitor; read/write them under the
+        // same lock that start()/stop() use, so a reconnect triggered from a disconnect/executor
+        // thread can never observe a stale isRunning after stop() (JMM visibility) and never races
+        // a concurrent stop() between the check and scheduling.
+        synchronized (this.lifecycleMonitor) {
+            webSocketSession = null;
+            if (this.isRunning) {
+                val baseDelay = afterDisconnect ? disconnectTimeout : Duration.ZERO;
+                val randomDelay = Duration.ofMillis(RANDOM.nextLong(reconnectTimeoutMin.toMillis(), reconnectTimeoutMax.toMillis() + 1));
+                val reconnectTimeoutMs = baseDelay.plus(randomDelay).toMillis();
+                log.info("Scheduling reconnect in {} ms", reconnectTimeoutMs);
+                try {
+                    Executor.getExecutor().schedule(this::openSession, reconnectTimeoutMs, TimeUnit.MILLISECONDS);
+                }
+                catch (Exception e) {
+                    log.error("Could not schedule reconnect", e);
+                }
             }
         }
     }
 
     private void openSession() {
-        if (this.isRunning) {
-            log.info("Initiate handshake with {}", this.uri);
-            // shake them hands...
-            webSocketClient.execute(this.vcmpHandler, this.headers, this.uri)
+        // Hold lifecycleMonitor across the isRunning check and the handshake kick-off so stop()
+        // cannot land between them (check-then-act). webSocketClient.execute() submits the handshake
+        // to an async executor and returns immediately, so the lock is not held across blocking I/O.
+        synchronized (this.lifecycleMonitor) {
+            if (this.isRunning) {
+                log.info("Initiate handshake with {}", this.uri);
+                // shake them hands...
+                webSocketClient.execute(this.vcmpHandler, this.headers, this.uri)
                     .thenAccept(session -> {
                         // The handshake completes asynchronously, so stop() may already have run by
                         // the time we get here. Decide what to do under the same lock stop() uses:
@@ -203,6 +213,7 @@ public class VcmpConnectionManager implements Closeable {
                         scheduleReconnect(false);
                         return null;
                     });
+            }
         }
     }
 

--- a/src/test/java/com/variocube/vcmp/client/VcmpConnectionManagerTest.java
+++ b/src/test/java/com/variocube/vcmp/client/VcmpConnectionManagerTest.java
@@ -1,0 +1,89 @@
+package com.variocube.vcmp.client;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the asynchronous handshake-completion guard added for issue #15 / PR #14.
+ *
+ * <p>The handshake completes asynchronously, so {@code stop()} may run while {@code webSocketSession}
+ * is still null. These tests drive that window deterministically by injecting a mock client whose
+ * handshake future we complete by hand, after {@code stop()} has already run.
+ */
+class VcmpConnectionManagerTest {
+
+    /**
+     * Reproduces the leak window: the handshake completes <em>after</em> {@code stop()}. The guard in
+     * {@code openSession()} must close the freshly-established session instead of publishing it.
+     */
+    @Test
+    void closesSessionEstablishedAfterStop() throws Exception {
+        val manager = new VcmpConnectionManager(new Object(), "ws://localhost/test");
+        val handshake = new CompletableFuture<WebSocketSession>();
+        injectClient(manager, handshake);
+
+        manager.start(); // kicks off the handshake; the future stays pending
+        manager.stop();  // isRunning = false; closeSession() finds webSocketSession still null
+
+        val session = mock(WebSocketSession.class);
+        handshake.complete(session); // handshake lands a moment too late
+
+        // The session established after stop() must be closed, not leaked or published.
+        verify(session).close();
+        assertThat(sessionField(manager)).isNull();
+    }
+
+    /**
+     * Sanity check the happy path is untouched: a handshake that completes while still running
+     * publishes the session and does not close it.
+     */
+    @Test
+    void publishesSessionEstablishedWhileRunning() throws Exception {
+        val manager = new VcmpConnectionManager(new Object(), "ws://localhost/test");
+        val handshake = new CompletableFuture<WebSocketSession>();
+        injectClient(manager, handshake);
+
+        manager.start();
+        val session = mock(WebSocketSession.class);
+        handshake.complete(session);
+
+        assertThat(sessionField(manager)).isSameAs(session);
+        verify(session, never()).close();
+
+        manager.stop();
+    }
+
+    private static void injectClient(VcmpConnectionManager manager, CompletableFuture<WebSocketSession> handshake)
+            throws Exception {
+        val client = mock(StandardWebSocketClient.class);
+        when(client.execute(any(WebSocketHandler.class), any(WebSocketHttpHeaders.class), any(URI.class)))
+                .thenReturn(handshake);
+        setField(manager, "webSocketClient", client);
+    }
+
+    private static WebSocketSession sessionField(VcmpConnectionManager manager) throws Exception {
+        val field = VcmpConnectionManager.class.getDeclaredField("webSocketSession");
+        field.setAccessible(true);
+        return (WebSocketSession) field.get(manager);
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        val field = VcmpConnectionManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up from review of #14. `VcmpConnectionManager.isRunning` is a plain `boolean`: written under `lifecycleMonitor` in `start()`/`stop()`, but read **without** the lock in `scheduleReconnect()` and `openSession()`.

- **Visibility**: the JMM permits the reconnect/executor thread to observe a stale `isRunning` after `stop()`.
- **Check-then-act**: `openSession()` does `if (isRunning)` then `webSocketClient.execute(...)` unlocked, so `stop()` can land between the check and the handshake kick-off.
- `scheduleReconnect()` also mutated `webSocketSession` outside the lock.

## Fix

Take `lifecycleMonitor` around the reads/writes in both `scheduleReconnect()` and `openSession()`. Chose locking over `volatile` because `volatile` fixes visibility only and leaves the check-then-act open. With all access under the one monitor, `volatile` is unnecessary.

### Regression analysis
- Single reentrant monitor → no lock ordering, no deadlock. `close()` → `handleDisconnect` → `scheduleReconnect` now takes the lock: reentrant on the same thread, a no-op on another (`isRunning == false`).
- `webSocketClient.execute()` submits the handshake to an async executor and returns immediately, so the lock is **not** held across blocking I/O.

## Tests

`VcmpConnectionManagerTest` — 2 deterministic unit tests, no CPU-pressure flakiness, no production seam (reflection-injected mock client):

1. `closesSessionEstablishedAfterStop` — completes the handshake future after `stop()`; asserts the fresh session is closed and never published.
2. `publishesSessionEstablishedWhileRunning` — happy path unchanged.

Closes #15