### PR TITLE
feat: daemon threads, ready-gate for handshakes, bounded connect concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ In order to test locally, you can publish a version to your local maven reposito
 ```shell
 ./gradlew -Pversion=0.0.0 publishToMavenLocal
 ```
+
+## Threading
+
+VCMP schedules its work on a shared pool of **daemon** threads (`VCMP-Worker-*`, `VCMP-Scheduler-*`).
+They never keep a JVM alive: if application startup fails, the process can exit and a container
+restart policy can recover (see variocube/center#427).
+
+## Server startup robustness
+
+Servers embedding VCMP endpoints get two protections against fleet-wide reconnect storms racing
+application startup (the web server port opens before startup has finished):
+
+| Property | Default | Meaning |
+|----------|---------|---------|
+| `vcmp.server.ready-gate.enabled` | `true` | Reject websocket handshakes with `503` + `Retry-After` until `ApplicationReadyEvent`. The filter runs at highest precedence, before Spring Security. Clients reconnect with retry. |
+| `vcmp.server.connect-concurrency` | `8` | Bound on concurrently running `@VcmpSessionConnected` handlers, shared across all endpoints of the application. Queues connect storms instead of exhausting resources (e.g. the DB pool). `<= 0` disables throttling. |

--- a/src/main/java/com/variocube/vcmp/Executor.java
+++ b/src/main/java/com/variocube/vcmp/Executor.java
@@ -38,12 +38,17 @@ public class Executor {
     private Thread schedulerThreadFactory(Runnable r) {
         val thread = Executors.defaultThreadFactory().newThread(r);
         thread.setName(String.format("VCMP-Scheduler-%s", numSchedulers.addAndGet(1)));
+        thread.setDaemon(true);
         return thread;
     }
 
     private Thread workerThreadFactory(Runnable r) {
         val thread = Executors.defaultThreadFactory().newThread(r);
         thread.setName(String.format("VCMP-Worker-%s", numWorkers.addAndGet(1)));
+        // Daemon: VCMP threads must never be the reason a JVM stays alive. With non-daemon
+        // threads, a failed application startup leaves a zombie process that a container
+        // restart policy cannot recover (variocube/center#427).
+        thread.setDaemon(true);
         return thread;
     }
 

--- a/src/main/java/com/variocube/vcmp/VcmpHandler.java
+++ b/src/main/java/com/variocube/vcmp/VcmpHandler.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
 import java.util.stream.Stream;
 
 import static com.variocube.vcmp.ObjectMapperHolder.createObjectMapper;
@@ -38,6 +39,15 @@ public final class VcmpHandler implements WebSocketHandler {
     @Setter
     private Runnable disconnectHandler;
 
+    /**
+     * Optional semaphore bounding how many connect handlers run concurrently. Connect handlers
+     * typically perform several DB operations; on a server, a fleet-wide reconnect storm would
+     * otherwise exhaust the DB pool (variocube/center#427). Shared across all handlers of an
+     * application so the bound covers all endpoints competing for the same resources.
+     */
+    @Setter
+    private Semaphore connectThrottle;
+
     public VcmpHandler(Object target) {
 
         this.target = target;
@@ -56,11 +66,20 @@ public final class VcmpHandler implements WebSocketHandler {
         sessions.put(session.getId(), vcmpSession);
 
         Executor.getExecutor().submit(() -> {
+            val throttle = this.connectThrottle;
+            if (throttle != null) {
+                throttle.acquireUninterruptibly();
+            }
             try {
                 MethodAnnotationUtils.invokeMethodWithAnnotation(this.target, VcmpSessionConnected.class, vcmpSession);
             }
             catch (Exception e) {
                 log.error("Could not invoke connect handler", e);
+            }
+            finally {
+                if (throttle != null) {
+                    throttle.release();
+                }
             }
         });
     }

--- a/src/main/java/com/variocube/vcmp/server/VcmpReadyGateFilter.java
+++ b/src/main/java/com/variocube/vcmp/server/VcmpReadyGateFilter.java
@@ -1,0 +1,62 @@
+package com.variocube.vcmp.server;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Rejects websocket handshakes until the application is fully started.
+ *
+ * Tomcat opens its port before {@code ApplicationReadyEvent} fires, so on a restart a fleet of
+ * VCMP clients reconnects while startup is still in progress. The work done per connect
+ * (handshake authentication, connect handlers) can starve resources — e.g. the DB pool — that
+ * startup itself still needs (variocube/center#427). Answering handshakes with 503 until ready
+ * is safe: VCMP clients reconnect with retry, so the startup window is indistinguishable from
+ * the port not being open yet.
+ *
+ * Runs at highest precedence so rejected handshakes don't even reach the security filter chain
+ * and its potentially DB-backed authentication.
+ *
+ * Disable with {@code vcmp.server.ready-gate.enabled=false}.
+ */
+@Slf4j
+public final class VcmpReadyGateFilter extends OncePerRequestFilter implements Ordered {
+
+    private volatile boolean ready = false;
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void handleApplicationReady() {
+        log.info("Application ready, accepting websocket handshakes.");
+        this.ready = true;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!ready && isWebSocketHandshake(request)) {
+            log.info("Rejecting websocket handshake for {} before application ready.", request.getRequestURI());
+            response.setHeader("Retry-After", "5");
+            response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE, "Starting up");
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private static boolean isWebSocketHandshake(HttpServletRequest request) {
+        String upgrade = request.getHeader("Upgrade");
+        return upgrade != null && upgrade.equalsIgnoreCase("websocket");
+    }
+}

--- a/src/main/java/com/variocube/vcmp/server/VcmpServerAutoConfiguration.java
+++ b/src/main/java/com/variocube/vcmp/server/VcmpServerAutoConfiguration.java
@@ -4,7 +4,9 @@ import com.variocube.vcmp.ClassUtils;
 import com.variocube.vcmp.VcmpHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -14,6 +16,7 @@ import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
 import java.util.Map;
+import java.util.concurrent.Semaphore;
 
 @Configuration
 @Conditional(VcmpEndpointCondition.class)
@@ -22,11 +25,17 @@ import java.util.Map;
 @EnableWebSocket
 public class VcmpServerAutoConfiguration implements WebSocketConfigurer {
 
+    static final int DEFAULT_CONNECT_CONCURRENCY = 8;
+
     private final ApplicationContext applicationContext;
     private final Environment environment;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        // Bound connect-handler concurrency across all endpoints of this application:
+        // they compete for the same resources (DB pool), so the bound must be shared.
+        Semaphore connectThrottle = createConnectThrottle();
+
         Map<String, Object> endpointBeans = applicationContext.getBeansWithAnnotation(VcmpEndpoint.class);
         for (Object endpoint : endpointBeans.values()) {
             Class<?> endpointClass = ClassUtils.getTargetClass(endpoint);
@@ -35,10 +44,29 @@ public class VcmpServerAutoConfiguration implements WebSocketConfigurer {
             String path = environment.resolveRequiredPlaceholders(vcmpEndpoint.path());
             if (StringUtils.hasText(path)) {
                 log.info("Registering endpoint {} with {}", path, endpoint.getClass().getSimpleName());
-                registry.addHandler(new VcmpHandler(endpoint), path)
+                VcmpHandler handler = new VcmpHandler(endpoint);
+                handler.setConnectThrottle(connectThrottle);
+                registry.addHandler(handler, path)
                         .setAllowedOrigins("*");
             }
         }
+    }
+
+    private Semaphore createConnectThrottle() {
+        int connectConcurrency = environment.getProperty("vcmp.server.connect-concurrency",
+                Integer.class, DEFAULT_CONNECT_CONCURRENCY);
+        if (connectConcurrency <= 0) {
+            log.info("VCMP connect throttling is disabled.");
+            return null;
+        }
+        log.info("Bounding concurrent VCMP connect handlers to {}.", connectConcurrency);
+        return new Semaphore(connectConcurrency);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "vcmp.server.ready-gate.enabled", havingValue = "true", matchIfMissing = true)
+    public VcmpReadyGateFilter vcmpReadyGateFilter() {
+        return new VcmpReadyGateFilter();
     }
 
 }

--- a/src/test/java/com/variocube/vcmp/ConnectThrottleTest.java
+++ b/src/test/java/com/variocube/vcmp/ConnectThrottleTest.java
@@ -1,0 +1,65 @@
+package com.variocube.vcmp;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ConnectThrottleTest {
+
+    static class Target {
+        final AtomicInteger running = new AtomicInteger();
+        final AtomicInteger maxRunning = new AtomicInteger();
+        final CountDownLatch done = new CountDownLatch(CONNECTS);
+
+        @VcmpSessionConnected
+        public void handleConnected(VcmpSession session) throws InterruptedException {
+            int now = running.incrementAndGet();
+            maxRunning.accumulateAndGet(now, Math::max);
+            Thread.sleep(20);
+            running.decrementAndGet();
+            done.countDown();
+        }
+    }
+
+    static final int CONNECTS = 10;
+
+    @Test
+    void boundsConnectHandlerConcurrency() throws Exception {
+        Target target = new Target();
+        VcmpHandler handler = new VcmpHandler(target);
+        handler.setConnectThrottle(new Semaphore(2));
+
+        for (int i = 0; i < CONNECTS; i++) {
+            handler.afterConnectionEstablished(mockSession("session-" + i));
+        }
+
+        assertThat(target.done.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(target.maxRunning.get()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void runsUnthrottledWithoutSemaphore() throws Exception {
+        Target target = new Target();
+        VcmpHandler handler = new VcmpHandler(target);
+
+        for (int i = 0; i < CONNECTS; i++) {
+            handler.afterConnectionEstablished(mockSession("session-" + i));
+        }
+
+        assertThat(target.done.await(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private static WebSocketSession mockSession(String id) {
+        WebSocketSession session = mock(WebSocketSession.class);
+        when(session.getId()).thenReturn(id);
+        return session;
+    }
+}

--- a/src/test/java/com/variocube/vcmp/ExecutorTest.java
+++ b/src/test/java/com/variocube/vcmp/ExecutorTest.java
@@ -1,0 +1,29 @@
+package com.variocube.vcmp;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExecutorTest {
+
+    @Test
+    void workerThreadsAreDaemon() throws Exception {
+        CompletableFuture<Thread> thread = new CompletableFuture<>();
+        Executor.getExecutor().submit(() -> thread.complete(Thread.currentThread()));
+
+        assertThat(thread.get(3, TimeUnit.SECONDS).isDaemon())
+                .as("VCMP worker threads must be daemon, they must not keep a JVM alive (center#427)")
+                .isTrue();
+    }
+
+    @Test
+    void schedulerDispatchesToDaemonWorker() throws Exception {
+        CompletableFuture<Thread> thread = new CompletableFuture<>();
+        Executor.getExecutor().schedule(() -> thread.complete(Thread.currentThread()), 1, TimeUnit.MILLISECONDS);
+
+        assertThat(thread.get(3, TimeUnit.SECONDS).isDaemon()).isTrue();
+    }
+}

--- a/src/test/java/com/variocube/vcmp/server/VcmpReadyGateFilterTest.java
+++ b/src/test/java/com/variocube/vcmp/server/VcmpReadyGateFilterTest.java
@@ -1,0 +1,58 @@
+package com.variocube.vcmp.server;
+
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VcmpReadyGateFilterTest {
+
+    @Test
+    void rejectsWebSocketHandshakeBeforeReady() throws Exception {
+        val filter = new VcmpReadyGateFilter();
+        val response = new MockHttpServletResponse();
+        val chain = new MockFilterChain();
+
+        filter.doFilter(webSocketHandshakeRequest(), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(503);
+        assertThat(response.getHeader("Retry-After")).isEqualTo("5");
+        assertThat(chain.getRequest()).isNull();
+    }
+
+    @Test
+    void acceptsWebSocketHandshakeAfterReady() throws Exception {
+        val filter = new VcmpReadyGateFilter();
+        filter.handleApplicationReady();
+        val response = new MockHttpServletResponse();
+        val chain = new MockFilterChain();
+
+        filter.doFilter(webSocketHandshakeRequest(), response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    @Test
+    void acceptsPlainHttpRequestBeforeReady() throws Exception {
+        val filter = new VcmpReadyGateFilter();
+        val request = new MockHttpServletRequest("GET", "/actuator/health");
+        val response = new MockHttpServletResponse();
+        val chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(chain.getRequest()).isNotNull();
+    }
+
+    private static MockHttpServletRequest webSocketHandshakeRequest() {
+        val request = new MockHttpServletRequest("GET", "/api/vcmp");
+        request.addHeader("Upgrade", "websocket");
+        request.addHeader("Connection", "Upgrade");
+        return request;
+    }
+}


### PR DESCRIPTION
Fixes #20. Root-cause fixes for variocube/center#427 (2026-07-09 production incident), so every VCMP server benefits — center#428 will consume this instead of app-local workarounds.

## Changes

- **Daemon threads** (`Executor`): scheduler and worker thread factories now mark threads daemon. VCMP threads must never be the reason a JVM stays alive — previously, a failed `SpringApplication.run` left a zombie process that Docker's `restart: always` could not recover.
- **Ready gate** (`VcmpReadyGateFilter`): registered by `VcmpServerAutoConfiguration`, answers websocket upgrade requests with **503 + Retry-After** until `ApplicationReadyEvent`. Runs at `Ordered.HIGHEST_PRECEDENCE`, before Spring Security, so a reconnect storm during startup cannot trigger DB-backed handshake auth. Disable with `vcmp.server.ready-gate.enabled=false`.
- **Bounded connect concurrency** (`VcmpHandler.setConnectThrottle`): the server auto-configuration shares one `Semaphore` across all endpoints of the app (they compete for the same DB pool). Configure with `vcmp.server.connect-concurrency` (default 8, `<= 0` disables). Client connections are unaffected.

Both server features are default-on: a 503 during the startup window is indistinguishable from the port not being open yet, and all VCMP clients reconnect with retry.

## Testing

- New: `ExecutorTest` (threads are daemon), `VcmpReadyGateFilterTest` (503 before ready / pass-through after / plain HTTP untouched), `ConnectThrottleTest` (concurrency bound, unthrottled without semaphore).
- Full `./gradlew build` passes — the existing integration tests run with both features active at their defaults.

## Docs

`README.md` documents the daemon-thread behavior and the two new `vcmp.server.*` properties.

## Note

README says features should also go to the `v2` (Spring Boot 2) branch — it has been dormant since 2024-02; the backport (javax servlet API for the filter) is left as a follow-up if still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)